### PR TITLE
ci: Remove branch cache after PR merged

### DIFF
--- a/.github/workflows/delete-branch-cache.yml
+++ b/.github/workflows/delete-branch-cache.yml
@@ -11,3 +11,6 @@ jobs:
       - uses: snnaplab/delete-branch-cache-action@v1
         with:
           ref: refs/pull/${{ github.event.number }}/merge
+      - uses: snnaplab/delete-branch-cache-action@v1
+        with:
+          ref: ${{ github.head_ref }}


### PR DESCRIPTION
```
Cache restored successfully
Cache restored from key: node-cache-Linux-npm-21c6c2e9c658ce0a114f6929c07b2b2fefce9a6fa77acb1f406054885a63f337
Received 2300395 of 2300395 (100.0%), 2.2 MBs/sec
```

```
Cache hit occurred on the primary key node-cache-Linux-npm-2[1](https://github.com/toshimaru/Test/actions/runs/7776376059/job/21203452967?pr=107#step:8:1)c6c[2](https://github.com/toshimaru/Test/actions/runs/7776376059/job/21203452967?pr=107#step:8:2)e9c658ce0a114f6929c07b2b2fefce9a6fa77acb1f406054885a6[3](https://github.com/toshimaru/Test/actions/runs/7776376059/job/21203452967?pr=107#step:8:3)f33[7](https://github.com/toshimaru/Test/actions/runs/7776376059/job/21203452967?pr=107#step:8:7), not saving cache.
```