### PR TITLE
fix: `pull_request_target.closed`

### DIFF
--- a/.github/workflows/cache-test.yml
+++ b/.github/workflows/cache-test.yml
@@ -2,7 +2,9 @@ name: Delete Action Cache (test)
 on:
   push:
   pull_request:
-    types: [merged]
+    types: [closed]
+  pull_request_target:
+    types: [closed]
 jobs:
   wip:
     runs-on: ubuntu-latest


### PR DESCRIPTION
follows #120 


## Result

### pull_request

```bash
  echo "refs/pull/120/merge" # ref
  echo "action-cache-test"  # head_ref
  echo "120" # number
```

#### closed event

```
```

### push

```bash
  echo "refs/heads/action-cache-test"
  echo ""
  echo ""
```